### PR TITLE
Fix exception while reducing exploits list

### DIFF
--- a/scans/task_mapper.py
+++ b/scans/task_mapper.py
@@ -52,7 +52,7 @@ class TaskMapper:
                 period = parse_period(periods.get(scan['exploit_name'], None) or
                                       cfg.get('tools.{0}.period'.format(app)))
 
-                if scan['scan_end'] + period > time.time():
+                if scan['scan_end'] + period > time.time() and scan['exploit'] in exploits:
                     exploits.remove(scan['exploit'])
 
             if not isinstance(port, SpecialPort):


### PR DESCRIPTION
### Description
There was exception while reducing exploits list, if exploit didn't exist on the list.
The reason could be e.g. change of target port service.

### Status
- [x] Trello card connected
- [x] Unit tests
- [x] Integration tests
- [x] Dockerization / Puppetization
- [ ] Tested on dev server
- [x] Dependencies are in master
