### PR TITLE
Fix race condition while storage initialization

### DIFF
--- a/tests/test_utils/test_storage.py
+++ b/tests/test_utils/test_storage.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 from sqlite3 import Connection, DatabaseError, time
 
 from sqlite3 import connect
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 
 from fixtures.exploits import Exploit
 from structs import Node, Port, TransportProtocol, Scan
@@ -264,3 +264,14 @@ class StorageTest(TestCase):
         expected = "DELETE FROM scans WHERE scan_start >= scan_end OR scan_start IS NULL OR SCAN_END IS NULL",
 
         self.assertEqual(result, expected)
+
+    def test_init_schema(self):
+        self.storage.execute = MagicMock()
+        self.storage.clear_scan_details = MagicMock()
+        self.storage.create_tables = MagicMock()
+
+        self.storage.init_schema()
+        self.storage.execute.assert_has_calls((call(self.storage.create_tables.return_value),
+                                               call(self.storage.clear_scan_details.return_value)), any_order=False)
+        self.storage.clear_scan_details.assert_called_once_with()
+        self.storage.create_tables.assert_called_once_with()

--- a/threads/storage_thread.py
+++ b/threads/storage_thread.py
@@ -26,8 +26,6 @@ class StorageThread(Thread):
         self.filename = filename
         self._queue = Queue()
         self._storage = Storage(self.filename)
-        self.create_tables()
-        self.clear_scan_details()
         self.finish = False
 
     def run(self):
@@ -43,6 +41,7 @@ class StorageThread(Thread):
 
         """
         self._storage.connect()
+        self._storage.init_schema()
 
         while not self.finish:
             try:
@@ -50,23 +49,7 @@ class StorageThread(Thread):
             except Empty:
                 continue
 
-            if isinstance(query, list):
-                log.debug("executing %i queries", len(query))
-                for row in query:
-                    self._storage.cursor.execute(*row)
-            elif isinstance(query, StorageQuery):
-                try:
-                    query.result = self._storage.cursor.execute(*query.query).fetchall()
-                except Exception:
-                    log.exception("Exception while executing query: %s", query.query[0])
-                finally:
-                    query.semaphore.release()
-                    self._queue.task_done()
-                continue
-            else:
-                log.debug("executing query: %s", query[0])
-                self._storage.cursor.execute(*query)
-            self._storage.conn.commit()
+            self._storage.execute(query)
             self._queue.task_done()
         self._storage.close()
         log.debug("Exit")


### PR DESCRIPTION
### Description
There is possible race condition while accessing to the storage queue. This PR fix it.

### Status
- [ ] Trello card connected
- [x] Unit tests
- [x] Integration tests
- [x] Dockerization / Puppetization
- [ ] Tested on dev server
- [ ] Dependencies are in master