### PR TITLE
Use parser objects instead of classes

### DIFF
--- a/tests/test_tools/test_common/test_parsers.py
+++ b/tests/test_tools/test_common/test_parsers.py
@@ -8,8 +8,11 @@ from utils.exceptions import NonXMLOutputException
 class ParserTest(TestCase):
     OUTPUT = 'TEST_output'
 
+    def setUp(self):
+        self.parser = Parser()
+
     def test_parse(self):
-        self.assertEqual(Parser.parse(self.OUTPUT), self.OUTPUT)
+        self.assertEqual(self.parser.parse(self.OUTPUT), self.OUTPUT)
 
 class ParserXMLTest(TestCase):
     NON_XML = '''This is non XML output!'''
@@ -18,8 +21,11 @@ class ParserXMLTest(TestCase):
         </script>
         '''
 
+    def setUp(self):
+        self.parser = XMLParser()
+
     def test_parse(self):
-        self.assertIsInstance(XMLParser.parse(self.SCRIPT_XML), ElementTree.Element)
+        self.assertIsInstance(self.parser.parse(self.SCRIPT_XML), ElementTree.Element)
 
     def test_parse_non_xml(self):
-        self.assertRaises(NonXMLOutputException, XMLParser.parse, self.NON_XML)
+        self.assertRaises(NonXMLOutputException, self.parser.parse, self.NON_XML)

--- a/tests/test_tools/test_hydra/test_parsers.py
+++ b/tests/test_tools/test_hydra/test_parsers.py
@@ -23,8 +23,11 @@ Hydra (http://www.thc.org/thc-hydra) starting at 2016-08-09 15:46:32
     OUTPUT_ERROR_LINE = r"[ERROR] could not connect to ssh://192.168.56.102:29 - Connection refused"
     OUTPUT_DATA_LINE = r"[DATA] attacking service ssh on port 29"
 
+    def setUp(self):
+        self.parser = HydraParser()
+
     def test_parse(self):
-        result = HydraParser.parse(stdout=self.OUTPUT)
+        result = self.parser.parse(stdout=self.OUTPUT)
         self.assertEqual(result.success, 1)
         self.assertEqual(result.fail, 0)
         self.assertEqual(len(result), 1)
@@ -36,7 +39,7 @@ Hydra (http://www.thc.org/thc-hydra) starting at 2016-08-09 15:46:32
         self.assertEqual(result[0].host, '192.168.56.102')
 
     def test_parse_output_with_space_password(self):
-        result = HydraParser.from_output(self.OUTPUT_LINE_WITH_SPACE_PASSWORD)
+        result = self.parser.from_output(self.OUTPUT_LINE_WITH_SPACE_PASSWORD)
         self.assertEqual(result.port, 80)
         self.assertEqual(result.service, 'http-get')
         self.assertEqual(result.host, '192.168.56.102')
@@ -44,7 +47,7 @@ Hydra (http://www.thc.org/thc-hydra) starting at 2016-08-09 15:46:32
         self.assertEqual(result.password, 'test_password ')
 
     def test_parse_output_space_login(self):
-        result = HydraParser.from_output(output=self.OUTPUT_LINE_WITH_SPACE_LOGIN)
+        result = self.parser.from_output(output=self.OUTPUT_LINE_WITH_SPACE_LOGIN)
         self.assertEqual(result.port, 80)
         self.assertEqual(result.service, 'http-get')
         self.assertEqual(result.host, '192.168.56.102')
@@ -52,13 +55,13 @@ Hydra (http://www.thc.org/thc-hydra) starting at 2016-08-09 15:46:32
         self.assertEqual(result.password, 'test_password')
 
     def test_output_error_line(self):
-        result = HydraParser.from_output(self.OUTPUT_ERROR_LINE)
+        result = self.parser.from_output(self.OUTPUT_ERROR_LINE)
         expected = None
 
         self.assertEqual(result, expected)
 
     def test_output_data_line(self):
-        result = HydraParser.from_output(self.OUTPUT_DATA_LINE)
+        result = self.parser.from_output(self.OUTPUT_DATA_LINE)
         expected = None
 
         self.assertEqual(result, expected)

--- a/tests/test_tools/test_skipfish/test_parsers.py
+++ b/tests/test_tools/test_skipfish/test_parsers.py
@@ -215,10 +215,13 @@ class SkipfishOutputParserTest(TestCase):
 [1;32m[+] [0;37mReport saved to '[1;34m/tmp/skipfish_1472650914.8062923/index.html[0;37m' [[1;34m0xdeae3458[0;37m].
 [1;32m[+] [1;37mThis was a great day for science![0m'''
 
+    def setUp(self):
+        self.parser = SkipfishOutputParser()
+
     def test_get_log_dir(self):
 
         expected = 'tmp/skipfish_Tue Aug 30 14:17:33 CEST 2016'
-        result = SkipfishOutputParser._get_log_dir(output=self.OUTPUT, directory='tmp')
+        result = self.parser._get_log_dir(output=self.OUTPUT, directory='tmp')
 
         self.assertEqual(result, expected)
 
@@ -227,7 +230,7 @@ class SkipfishOutputParserTest(TestCase):
     @patch('tools.skipfish.parsers.cfg.get', MagicMock(return_value='tmp/'))
     def test_parse(self, get_dir_mock, parser_mock):
         get_dir_mock.return_value = 'test'
-        SkipfishOutputParser.parse(self.OUTPUT)
+        self.parser.parse(self.OUTPUT)
 
         parser_mock.assert_called_once_with(directory='test')
         parser_mock.return_value.parse.assert_called_once_with()
@@ -236,7 +239,7 @@ class SkipfishOutputParserTest(TestCase):
     def test_get_log_dir_from_fetched_output(self):
 
         expected = '/tmp/skipfish_1472650914.8062923'
-        result = SkipfishOutputParser._get_log_dir(output=self.OUTPUT_FETCHED, directory='/tmp')
+        result = self.parser._get_log_dir(output=self.OUTPUT_FETCHED, directory='/tmp')
 
         self.assertEqual(result, expected)
 
@@ -245,7 +248,7 @@ class SkipfishOutputParserTest(TestCase):
     @patch('tools.skipfish.parsers.cfg.get', MagicMock(return_value='/tmp/'))
     def test_parse_fetched_output(self, get_dir_mock, parser_mock):
         get_dir_mock.return_value = 'test'
-        SkipfishOutputParser.parse(self.OUTPUT_FETCHED)
+        self.parser.parse(self.OUTPUT_FETCHED)
 
         parser_mock.assert_called_once_with(directory='test')
         parser_mock.return_value.parse.assert_called_once_with()

--- a/tools/common/command.py
+++ b/tools/common/command.py
@@ -21,7 +21,7 @@ class Command(object):
     #to be set by child classes.
     COMMON_ARGS = None
     NAME = None
-    parser = Parser
+    parser = Parser()
 
     def call(self, args=None):
         """

--- a/tools/common/parsers.py
+++ b/tools/common/parsers.py
@@ -12,8 +12,7 @@ class Parser(object):
     Return output
 
     """
-    @classmethod
-    def parse(cls, stdout, stderr=None):
+    def parse(self, stdout, stderr=None):
         """
         Return output
 
@@ -33,8 +32,7 @@ class XMLParser(Parser):
     Parser for XML output
 
     """
-    @classmethod
-    def parse(cls, stdout, stderr=None):
+    def parse(self, stdout, stderr=None):
         """
         Treats output as XML and return ElementTree object
 

--- a/tools/hydra/base.py
+++ b/tools/hydra/base.py
@@ -11,7 +11,7 @@ class HydraBase(Command):
     """
     COMMON_ARGS = ('-t', '4')
     NAME = 'hydra'
-    parser = HydraParser
+    parser = HydraParser()
 
     SUPORTED_SERVICES = ['asterisk', 'cisco', 'cisco-enable', 'cvs', 'firebird', 'ftp', 'ftps', 'http-get', 'http-post',
                          'http-head', 'https-get', 'https-post', 'https-head', 'http-get-form', 'http-post-form',

--- a/tools/hydra/parsers.py
+++ b/tools/hydra/parsers.py
@@ -32,8 +32,7 @@ class HydraParser(Parser):
     regex_summary = re.compile(SUMMARY_PATTERN)
     regex_all = re.compile(ALL_PATTERN)
 
-    @classmethod
-    def parse(cls, stdout, stderr=None):
+    def parse(self, stdout, stderr=None):
         """
         Parses output and return collection of Hydra Results
 
@@ -47,11 +46,11 @@ class HydraParser(Parser):
         """
         results = HydraResults()
         for line in stdout.split("\n"):
-            match = cls.regex_all.match(line)
+            match = self.regex_all.match(line)
 
             if match.group('success_match'):
                 log.debug("Hydra: %s", line)
-                results.add(cls.from_re_match(match))
+                results.add(self.from_re_match(match))
 
             elif match.group('summary_match'):
                 log.debug("Hydra: %s", line)
@@ -65,8 +64,7 @@ class HydraParser(Parser):
 
         return results
 
-    @classmethod
-    def from_output(cls, output):
+    def from_output(self, output):
         """
         Converts hydra output line to Hydra Result
 
@@ -77,10 +75,9 @@ class HydraParser(Parser):
             HydraResult|None
 
         """
-        return cls.from_re_match(cls.regex_success.match(output))
+        return self.from_re_match(self.regex_success.match(output))
 
-    @classmethod
-    def from_re_match(cls, match):
+    def from_re_match(self, match):
         """
         Converts matching regex to Hydra Result
 

--- a/tools/masscan/base.py
+++ b/tools/masscan/base.py
@@ -13,4 +13,4 @@ class MasscanBase(Command):
     """
     COMMON_ARGS = ('-oX', '-')
     NAME = 'masscan'
-    parser = XMLParser
+    parser = XMLParser()

--- a/tools/nmap/base.py
+++ b/tools/nmap/base.py
@@ -13,7 +13,7 @@ class NmapBase(Command):
     """
     COMMON_ARGS = ('-n', '--privileged', '-oX', '-', '-T4')
     NAME = 'nmap'
-    parser = XMLParser
+    parser = XMLParser()
 
 
 class NmapScript(object):

--- a/tools/skipfish/parsers.py
+++ b/tools/skipfish/parsers.py
@@ -112,8 +112,7 @@ class SkipfishOutputParser(Parser):
     Provides functions for parsing skipfish stdout
 
     """
-    @classmethod
-    def parse(cls, stdout, stderr=None):
+    def parse(self, stdout, stderr=None):
         """
         Prepares skipfish's report parser
 
@@ -125,12 +124,11 @@ class SkipfishOutputParser(Parser):
             SkipfishIssues object
 
         """
-        parser = SkipfishResultsParser(directory=cls._get_log_dir(output=stdout,
-                                                                  directory=cfg['tools.skipfish.tmp_directory']))
+        parser = SkipfishResultsParser(directory=self._get_log_dir(output=stdout,
+                                                                   directory=cfg['tools.skipfish.tmp_directory']))
         return parser.parse()
 
-    @classmethod
-    def _get_log_dir(cls, output, directory):
+    def _get_log_dir(self, output, directory):
         """
         Parse skipfish output and return path to log directory
 


### PR DESCRIPTION
### Description
Make tool parsers consistent.

### Status
- [ ] Trello card connected
- [ ] Unit tests
- [ ] Integration tests
- [ ] Dockerization / Puppetization
- [ ] Tested on dev server
- [ ] Dependencies are in master
