### PR TITLE
Fix SSLV3_ALERT_HANDSHAKE_FAILURE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,12 @@ nanomsg==1.0
 netaddr==0.7.18
 python-dateutil
 netifaces==0.10.5
-requests==2.11.1
+requests==2.14.2
 croniter==0.3.13
 pytz==2016.10
 inotify==0.2.8
 tornado==4.4.2
 tornado-crontab==0.3.2
+pyopenssl==17.0.0
+pyasn1==0.2.3
+ndg-httpsclient==0.4.2


### PR DESCRIPTION
### Description
Older version of requests cannot connect to some HTTPS websites.
This set of packages fix it for tested website:

requests==2.14.2
pyopenssl==17.0.0
pyasn1==0.2.3
ndg-httpsclient==0.4.2

### Status
- [ ] Trello card connected
- [ ] Unit tests
- [ ] Integration tests
- [ ] Dockerization / Puppetization
- [ ] Tested on dev server
- [ ] Dependencies are in master
