### PR TITLE
Handle invalid cron value

### DIFF
--- a/tests/test_utils/test_async_crontab_task.py
+++ b/tests/test_utils/test_async_crontab_task.py
@@ -104,3 +104,11 @@ class AsyncCrontabTaskTest(AsyncTestCase):
     def test_cron_callable(self):
         self.task._cron = MagicMock()
         self.assertEqual(self.task.cron, self.task._cron.return_value)
+
+    @gen_test
+    async def test_invalid_cron_value(self):
+        self.task._cron = ''
+        self.task._prepare_next_iteration = MagicMock()
+        await self.task()
+        self.assertFalse(self.func.called)
+        self.task._prepare_next_iteration.assert_called_once_with()

--- a/utils/async_crontab_task.py
+++ b/utils/async_crontab_task.py
@@ -53,24 +53,22 @@ class AsyncCrontabTask(object):
 
         self._is_running = True
 
-        current_time = time.time()
-        current_cron_time = int(current_time / 60) * 60
-        current_cron = croniter(self.cron, current_time - 60).next()
-
-        if current_cron != current_cron_time or current_cron_time == self._last_execute:
-            self._prepare_next_iteration()
-            return
-
-        self._last_execute = current_cron_time
-
-
         try:
+            current_time = time.time()
+            current_cron_time = int(current_time / 60) * 60
+            current_cron = croniter(self.cron, current_time - 60).next()
+
+            if current_cron != current_cron_time or current_cron_time == self._last_execute:
+                return
+
+            self._last_execute = current_cron_time
+
             log.debug("AsyncCrontabTask[%s]: Executing", self.func.__name__)
             await self.func()
+            log.debug("AsyncCrontabTask[%s]: Finished", self.func.__name__)
         except Exception:
             log.exception("AsyncCrontabTask[%s]: Exception", self.func.__name__)
         finally:
-            log.debug("AsyncCrontabTask[%s]: Finished", self.func.__name__)
             self._prepare_next_iteration()
 
     def is_running(self):


### PR DESCRIPTION
### Description

If cron value is invalid, aucote fails. This PR fix it, by ignoring exceptions and allowing to try taking config again and again.

### Status
- [x] Trello card connected
- [x] Unit tests
- [x] Integration tests
- [x] Dockerization / Puppetization
- [x] Tested on dev server
- [x] Dependencies are in master
