### PR TITLE
Allow additional arguments for masscan

### DIFF
--- a/aucote_cfg_default.yaml
+++ b/aucote_cfg_default.yaml
@@ -172,6 +172,7 @@ tools:
         script_networks: {}
     masscan:
         cmd: masscan
+        args: []
     hydra:
         cmd: hydra
         loginfile: static/logins.hydra.txt

--- a/tests/test_tools/test_masscan/test_ports.py
+++ b/tests/test_tools/test_masscan/test_ports.py
@@ -32,7 +32,8 @@ class MasscanPortsTest(TestCase):
             },
             'tools': {
                 'masscan': {
-                    'cmd': 'test'
+                    'cmd': 'test',
+                    'args': []
                 }
             }
         }
@@ -56,11 +57,16 @@ class MasscanPortsTest(TestCase):
                         'exclude': []
                     }
                 }
+            },
+            'tools': {
+                'masscan': {
+                    'args': ['test_additional_arg1', 'test_additional_arg2']
+                }
             }
         }
 
         result = self.masscanports.prepare_args(self.nodes)
-        expected = ['--rate', '1000',
+        expected = ['test_additional_arg1', 'test_additional_arg2', '--rate', '1000',
                     '--ports', 'T:17-45', self.NODE_IP]
 
         self.assertEqual(result, expected)
@@ -86,6 +92,11 @@ class MasscanPortsTest(TestCase):
                         'include': [],
                         'exclude': []
                     }
+                }
+            },
+            'tools': {
+                'masscan': {
+                    'args': []
                 }
             }
         }

--- a/tools/masscan/ports.py
+++ b/tools/masscan/ports.py
@@ -32,7 +32,8 @@ class MasscanPorts(ScanTask):
             list
 
         """
-        args = ['--rate', str(cfg['portdetection.network_scan_rate'])]
+        args = list(cfg['tools.masscan.args'])
+        args.extend(['--rate', str(cfg['portdetection.network_scan_rate'])])
 
         include_ports = NmapTool.list_to_ports_string(tcp=self.tcp and cfg['portdetection.ports.tcp.include'],
                                                       udp=self.udp and cfg['portdetection.ports.udp.include'])


### PR DESCRIPTION
### Description

Masscan requires additional arguments while using in some networks e.g. WiFi

### Use Case

There is no problem on production network, but it would be great to have control of arguments in local network. Especially for testing purposes

### Additional Information

Quick fix. Needs only small changes in code and puppetization

### Requires

Strict: Puppetization update

### Status
- [x] Trello card connected
- [x] Unit tests
- [x] Integration tests
- [x] Dockerization / Puppetization
- [x] Tested on dev server
- [x] Dependencies are in master
