### PR TITLE
Do not send empty Nmap results

### DIFF
--- a/tests/test_tools/test_nmap/test_parsers.py
+++ b/tests/test_tools/test_nmap/test_parsers.py
@@ -148,6 +148,9 @@ class NmapInfoParserTest(TestCase):
     VALID_OUTPUT = """<script output="test_output">
 </script>
 """
+    EMPTY_OUTPUT = """<script output="&#xa;">
+</script>
+"""
 
     ERROR_OUTPUT = """<script output="ERROR: test_output">
 </script>
@@ -169,6 +172,11 @@ class NmapInfoParserTest(TestCase):
         result = self.parser.parse(script)
         expected = 'test_output'
         self.assertEqual(result, expected)
+
+    def test_empty_output(self):
+        script = ElementTree.fromstring(self.EMPTY_OUTPUT)
+        result = self.parser.parse(script)
+        self.assertIsNone(result)
 
 
 class NmapParserTest(TestCase):

--- a/tools/nmap/parsers.py
+++ b/tools/nmap/parsers.py
@@ -44,6 +44,8 @@ class NmapInfoParser(NmapParser):
     """
     def _parse(self, script):
         output = script.get('output').strip()
+        if not output:
+            return None
         if output.startswith("ERROR: "):
             log.warning(output)
             return None


### PR DESCRIPTION
### Description

Do not report empty Nmap results as vulnerability

### Status
- [x] Trello card connected
- [x] Unit tests
- [x] Integration tests
- [x] Dockerization / Puppetization
- [x] Tested on dev server
- [x] Dependencies are in master
