### PR TITLE
Fix Error: "Too many open files"

### DIFF
--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -285,5 +285,5 @@ class ConfigTest(TestCase):
 
         partial.assert_called_once_with(self.config.toucan.get, 'test')
         ioloop().run_sync.assert_called_once_with(partial())
-        ioloop().close.assert_called_once_with(True)
+        ioloop().close.assert_called_once_with()
         self.assertEqual(result, expected)

--- a/utils/config.py
+++ b/utils/config.py
@@ -6,6 +6,7 @@ import time
 import logging as log
 from functools import partial
 
+import contextlib
 import yaml
 from tornado.ioloop import IOLoop
 
@@ -97,14 +98,8 @@ class Config:
         Returns:
 
         """
-        tmp_ioloop = IOLoop()
-        try:
-            return_value = tmp_ioloop.run_sync(partial(self.toucan.get, key))
-        finally:
-            tmp_ioloop.close(True)
-
-        return return_value
-
+        with contextlib.closing(IOLoop()) as ioloop:
+            return ioloop.run_sync(partial(self.toucan.get, key))
 
     def set(self, key, value):
         """


### PR DESCRIPTION
### Description

Before this PR aucote was creating a lot of IOLoop for toucan and didn't close it.

### Status
- [x] Trello card connected
- [x] Unit tests
- [x] Integration tests
- [x] Dockerization / Puppetization
- [x] Tested on dev server
- [x] Dependencies are in master
