### PR TITLE
Send information about node os in vulnerability

### DIFF
--- a/database/serializer.py
+++ b/database/serializer.py
@@ -44,6 +44,7 @@ class Serializer:
         msg.add_str(vuln.output if vuln is not None else '')
         msg.add_int(vuln.exploit.id if vuln is not None else 0)
         msg.add_datetime(vuln.when_discovered if vuln is not None else None)
+        msg.add_str(port.node.os.name_with_version if port.node.os.name_with_version is not None else '')
         return msg
 
     @classmethod

--- a/structs.py
+++ b/structs.py
@@ -258,6 +258,12 @@ class Service(object):
             return self._unescape_cpe(" ".join(self._cpe.get_vendor()))
 
     @property
+    def name_with_version(self):
+        if self.version is None or self.name is None:
+            return None
+        return "{name} {version}".format(name=self.name, version=self.version)
+
+    @property
     def cpe_product(self):
         """
         Get product name based on CPE

--- a/tests/test_database/test_serializer.py
+++ b/tests/test_database/test_serializer.py
@@ -1,7 +1,7 @@
 import datetime
 import ipaddress
 from unittest import TestCase
-from unittest.mock import PropertyMock, patch
+from unittest.mock import PropertyMock, patch, MagicMock
 
 from database.serializer import Serializer
 from fixtures.exploits import Exploit
@@ -17,7 +17,9 @@ class SerializerTest(TestCase):
         self.serializer = Serializer()
         self.vuln = Vulnerability()
 
-        node = Node(ip = ipaddress.ip_address('127.0.0.1'), node_id=1)
+        node = Node(ip=ipaddress.ip_address('127.0.0.1'), node_id=1)
+        node.os = MagicMock()
+        node.os.name_with_version = 'test_name_and_version'
 
         port = Port(node=node, number=22, transport_protocol=TransportProtocol.TCP)
         port.protocol = 'ssh'
@@ -44,7 +46,8 @@ class SerializerTest(TestCase):
         result = self.serializer.serialize_port_vuln(self.vuln.port, self.vuln).data
         expected = bytearray(b'\x00\x00\xe7\xfb\xf2\x93V\x01\x00\x00\x16\x00 \x02\x7f\x00\x00\x01\x00\x00\x00\x00\x00'
                              b'\x00\x00\x00\x00\x00\x01\x00\x00\x00\x03\x00ssh\x00\x00\x00\x00\x06\xe7\xfb\xf2\x93V\x01'
-                             b'\x00\x00\x04\x00Test\x01\x00\x00\x00\xe7\xfb\xf2\x93V\x01\x00\x00')
+                             b'\x00\x00\x04\x00Test\x01\x00\x00\x00\xe7\xfb\xf2\x93V\x01\x00\x00\x15\x00test_na'
+                             b'me_and_version')
 
         self.assertEqual(result, expected)
 


### PR DESCRIPTION
### Description

It would nice to have os information in csapp, and this PR solves this issue.

### Status
- [ ] Trello card connected
- [ ] Unit tests
- [ ] Integration tests
- [ ] Dockerization / Puppetization
- [ ] Tested on dev server
- [ ] Dependencies are in master
