### PR TITLE
Exclude raw printing from default config

### DIFF
--- a/aucote_cfg_default.yaml
+++ b/aucote_cfg_default.yaml
@@ -98,7 +98,7 @@ portdetection:
         tcp:
             include:
                 - 0-65535 # TCP: full range
-            exclude: []
+            exclude: [9100]
         udp:
             include:
                 - 0-65535 # UDP: full range


### PR DESCRIPTION
### Description

Exclude raw printing port from default config.

### Status
- [x] Trello card connected
- [ ] Unit tests
- [ ] Integration tests
- [x] Dockerization / Puppetization
- [ ] Tested on dev server
- [ ] Dependencies are in master
