### PR TITLE
Fix http-proxy url

### DIFF
--- a/structs.py
+++ b/structs.py
@@ -387,6 +387,10 @@ class Port(object):
     Port object
 
     """
+    PROTOCOLS_MAP = {
+        'http-proxy': 'http'
+    }
+
     def __init__(self, node, number, transport_protocol):
         """
         Args:
@@ -464,7 +468,8 @@ class Port(object):
             format_string = "{0}://[{1}]:{2}"
         else:
             format_string = "{0}://{1}:{2}"
-        return format_string.format(self.protocol, self.node.ip, self.number)
+
+        return format_string.format(self.PROTOCOLS_MAP.get(self.protocol, self.protocol), self.node.ip, self.number)
 
     def in_range(self, parsed_ports):
         """

--- a/tests/test_root/test_structs.py
+++ b/tests/test_root/test_structs.py
@@ -165,6 +165,15 @@ class PortTest(TestCase):
 
         self.assertEqual(port1.url, expected)
 
+    def test_get_url_http_proxy(self):
+        node1 = Node(ip=ipaddress.ip_address('::1'), node_id=1)
+        port1 = Port(node=node1, number=1, transport_protocol=TransportProtocol.TCP)
+        port1.protocol = 'http-proxy'
+
+        expected = "http://[::1]:1"
+
+        self.assertEqual(port1.url, expected)
+
     def test_copy(self):
         node1 = Node(ip=ipaddress.ip_address('127.0.0.1'), node_id=1)
         port = Port(node=node1, number=1, transport_protocol=TransportProtocol.TCP)


### PR DESCRIPTION
### Description

Represents http-proxy url as http://

### Status
- [x] Trello card connected
- [x] Unit tests
- [x] Integration tests
- [x] Dockerization / Puppetization
- [ ] Tested on dev server
- [ ] Dependencies are in master
