### PR TITLE
Fix whatweb assigning tasks for cve

### DIFF
--- a/tests/test_tools/test_hydra/test_tool.py
+++ b/tests/test_tools/test_hydra/test_tool.py
@@ -1,5 +1,4 @@
 import ipaddress
-from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
 from tornado.testing import gen_test, AsyncTestCase
@@ -8,7 +7,6 @@ from fixtures.exploits import Exploit
 from structs import RiskLevel, Port, Scan, Node, TransportProtocol
 from tools.hydra.tool import HydraTool
 from utils import Config
-from utils.storage import Storage
 
 
 class HydraToolTest(AsyncTestCase):

--- a/tools/whatweb/tasks.py
+++ b/tools/whatweb/tasks.py
@@ -66,4 +66,6 @@ class WhatWebTask(CommandTask):
         new_port = self.port.copy()
         new_port.apps = cpes
 
-        await self.aucote.task_mapper.assign_tasks(port=new_port, scripts=exploits)
+        from scans.task_mapper import TaskMapper  # ToDo: Solve circular dependencies by using context
+        await TaskMapper(aucote=self.aucote, scan=self._scan, scanner=self._scan.scanner).assign_tasks(port=new_port,
+                                                                                                       scripts=exploits)


### PR DESCRIPTION
### Description

Circular dependency will be fixed by creating scan context

### Status
- [x] [Trello card connected](https://trello.com/c/Lgvh1BRo/135-whatweb-cannot-execute-cve-search-search)
- [x] Unit tests
- [x] Integration tests
- [x] Dockerization / Puppetization
- [ ] Tested on dev server
- [ ] Dependencies are in master
