### PR TITLE
Use libnanomsg5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN echo "deb http://aptly.cs.int/public xenial $destEnv" >> /etc/apt/sources.li
 RUN printf "Package: * \nPin: release a=xenial, o=aptly.cs.int \nPin-Priority: 1600 \n" > /etc/apt/preferences
 
 
-RUN apt-get update && apt-get install -y software-properties-common python3-setuptools python3-pip python3-dev libyaml-dev libpq-dev nanomsg nanomsg-dev curl git bash
+RUN apt-get update && apt-get install -y software-properties-common python3-setuptools python3-pip python3-dev libyaml-dev libpq-dev libnanomsg5 libnanomsg-dev curl git bash
 RUN easy_install3 -U setuptools
 ADD internal_deps /internal_deps
 ADD requirements.txt requirements.txt

--- a/package.sh
+++ b/package.sh
@@ -11,7 +11,7 @@ PACKAGE_TARGET_PATH=${PACKAGE_PATH}/opt/${PACKAGE_NAME}
 PACKAGE_BIN_PATH=${PACKAGE_PATH}/bin/
 PACKAGE_START_SCRIPTS=start_scripts/*
 PYTHON_VERSION=python3
-DEPENDENCIES="python3 (>= 3.5), nanomsg, masscan, libpq5, libyaml-dev, nmap-aucote (>=7.40), hydra (>= 8.3), skipfish, whatweb, testssl.sh (>=2.8), polenum, enum4linux"
+DEPENDENCIES="python3 (>= 3.5), libnanomsg5, masscan, libpq5, libyaml-dev, nmap-aucote (>=7.40), hydra (>= 8.3), skipfish, whatweb, testssl.sh (>=2.8), polenum, enum4linux"
 
 [[ -z $VERSION ]] && { echo "Usage: package [version]"; exit 1; }
 


### PR DESCRIPTION
### Description
Use libnanomsg5 in place of deprecated nanomsg package.
This also implicitly upgrades nanomsg to version 1.1.2.

This PR depends on FCG-LLC/nanomsg#7

Build log of this change:
https://jenkins.cs.int/job/aucote-deb_container/429/console

### Screenshot

### Status
- [ ] Trello card connected
- [ ] Unit tests
- [ ] Integration tests
- [ ] Dockerization / Puppetization
- [ ] Tested on dev server
- [ ] Dependencies are in master
