### PR TITLE
Remove redundant exploit from exploits list

### DIFF
--- a/fixtures/exploits/exploits.csv
+++ b/fixtures/exploits/exploits.csv
@@ -317,7 +317,6 @@ ular website if it was disabled by the user. This header is supported in IE 8+, 
 159;nmap;ipmi-version;Detects ipmi version;Performs IPMI Information Discovery through Channel Auth probes.;None;;UDP:623;safe,version;;IPMI_OTHER
 160;nmap;ipmi-brute;IPMI brute force;Performs brute force password auditing against IPMI RPC server.;High;;UDP:623;brute,intrusive;;IPMI_BRUTE
 161;nmap;ipmi-dumphashes;Dumps IPMI password hashes;Try to dump password hashes frim IPMI RPC server.;High;;UDP:623;brute,intrusive;CVE-2013-4786;IPMI_DUMP
-162;nmap;supermicro-ipmi-conf;Downloads configuration from Supermicro Onboard IPMI controllers;Attempts to download an unprotected configuration file containing plain-text user credentials in vulnerable Supermicro Onboard IPMI controllers.;High;;UDP:623;exploit,vuln;;IPMI_OTHER
 163;nmap;http-email-harvest;Collects emails from website;Spiders a web site and collects e-mail addresses.;None;http,https,http-proxy;;safe;;HTTP_INFO
 164;nmap;http-method-tamper;Attempts to bypass password protected resources;"Attempts to bypass password protected resources (HTTP 401 status) by performing HTTP verb tampering.
 If an array of paths to check is not set, it will crawl the web server and perform the check against any


### PR DESCRIPTION
### Description

Remove duplication of supermicro-ipmi-conf

```
105;nmap;supermicro-ipmi-conf;Unprotected...
162;nmap;supermicro-ipmi-conf;Downloads c...
```

### Status
- [x] Trello card connected
- [ ] Unit tests
- [ ] Integration tests
- [ ] Dockerization / Puppetization
- [ ] Tested on dev server
- [x] Dependencies are in master
