### PR TITLE
Log error separated

### DIFF
--- a/tests/test_utils/test_log.py
+++ b/tests/test_utils/test_log.py
@@ -10,10 +10,10 @@ from utils.log import config
 class ConfigFileTest(AsyncTestCase):
 
     @patch('builtins.open', mock_open(read_data=""))
-    @patch('utils.log.RotatingFileHandler')
+    @patch('utils.log.setup_logger')
     @patch('utils.log.log')
     @gen_test
-    async def test_config(self, mock_log, mock_rotate):
+    async def test_config(self, mock_log, setup_logger):
         expected = [MagicMock(), MagicMock()]
         mock_log.getLogger().handlers = expected
         cfg = Config()
@@ -29,11 +29,8 @@ class ConfigFileTest(AsyncTestCase):
         }
         await config(cfg)
 
-        self.assertTrue(mock_log.StreamHandler.called)
-        self.assertTrue(mock_log.getLogger.called)
-        self.assertTrue(mock_log.getLogger.return_value.addHandler.called)
-
-        mock_rotate.assert_called_once_with('test_file', maxBytes=45678, backupCount=13)
-
-        mock_log.Formatter.assert_called_once_with('TEST format')
-        mock_log.getLogger().removeHandler.assert_has_calls((call(expected[1]), call(expected[0])))
+        setup_logger.assert_has_calls((
+            call(filename='test_file', level='info', log_format='TEST format', max_file_size=45678, max_files=13,
+                 name=None, propagate=True),
+            call(filename='test_file.WARNING', level='warning', log_format='TEST format', max_file_size=45678,
+                 max_files=13, name=None, propagate=True)))

--- a/utils/log.py
+++ b/utils/log.py
@@ -1,6 +1,6 @@
-'''
+"""
 Configures logging subsystem.
-'''
+"""
 import logging as log
 import sys
 


### PR DESCRIPTION
### Description

via trello

`
I think it will be nice if we will log errors in aucote.log fie and in additional separated file. The main reason is that aucote.log contains a lot of logs and it's hard to read it and find error logs, also because they can be overwritten.
`

### Status
- [x] Trello card connected
- [x] Unit tests
- [ ] Integration tests
- [x] Dockerization / Puppetization
- [ ] Tested on dev server
- [x] Dependencies are in master
