### PR TITLE
More verbosity for tasks left in queue

### DIFF
--- a/tests/test_utils/test_async_task_manager.py
+++ b/tests/test_utils/test_async_task_manager.py
@@ -172,6 +172,7 @@ class TestAsyncTaskManager(AsyncTestCase):
                 return 0
 
         self.task_manager._tasks = queue(task)
+        self.task_manager._tasks._queue = [task]  # Very awful mocking async queue
 
         yield self.task_manager.process_tasks(0)
         task.assert_called_once_with()


### PR DESCRIPTION
### Description

More verbosity for tasks left in queue

### Status
- [x] Trello card connected
- [ ] Unit tests
- [ ] Integration tests
- [x] Dockerization / Puppetization
- [x] Tested locally
- [x] Dependencies are in master
