### PR TITLE
Add version command

### DIFF
--- a/dockerization/hardened/Dockerfile
+++ b/dockerization/hardened/Dockerfile
@@ -29,4 +29,7 @@ RUN setcap 'cap_net_bind_service=+ep' /opt/aucote/venv/bin/python
 EXPOSE 1235
 
 COPY files/docker-entrypoint.sh /entrypoint.sh
+COPY files/version.sh /version.sh
+RUN ln -s /version.sh /usr/bin/version
+
 CMD ["/entrypoint.sh"]

--- a/dockerization/hardened/files/version.sh
+++ b/dockerization/hardened/files/version.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+dpkg-query -W aucote nmap-aucote libnanomsg5


### PR DESCRIPTION
`# docker run -it docker-registry.cs.int/dev/cs-aucote-hardened:perk version`
aucote  0.0.0-20180730122331-2e478a6
libnanomsg5     1.1.2-20180222131200-d2a22c6
nmap-aucote     7.40-1~20170410145351-0671000