### PR TITLE
:rocket: :spaghetti: Cancellable UDP scans

### DIFF
--- a/scans/scan_async_task.py
+++ b/scans/scan_async_task.py
@@ -13,7 +13,7 @@ from netaddr import IPSet
 
 from aucote_cfg import cfg
 from database.serializer import Serializer
-from structs import ScanType, ScanStatus, ScanContext, Service, Scan
+from structs import ScanType, ScanStatus, ScanContext, Service, Scan, TaskManagerType
 from utils.time import parse_period
 
 
@@ -62,9 +62,9 @@ class ScanAsyncTask(object):
             run_after = cfg['portdetection.{name}.run_after'.format(name=self.NAME)]
             for scan_name in run_after:
 
-                scan_task = self.aucote.async_task_manager.cron_task(scan_name)
+                scan_task = self.aucote.async_task_managers[TaskManagerType.SCANNER].cron_task(scan_name)
                 if scan_task is not None:
-                    self.aucote.ioloop.add_callback(partial(scan_task, run_now=True))
+                    self.aucote.ioloop.add_callback(partial(scan_task, skip_cron=True))
 
             return result
         finally:

--- a/tools/common/command.py
+++ b/tools/common/command.py
@@ -46,6 +46,9 @@ class Command(object):
         if args is None:
             args = []
 
+        if not timeout:
+            timeout = None
+
         all_args = [self.CMD if self.CMD is not None else cfg['tools.%s.cmd' % self.NAME]]
         all_args.extend(self.COMMON_ARGS)
         all_args.extend(args)

--- a/tools/nmap/ports.py
+++ b/tools/nmap/ports.py
@@ -28,7 +28,7 @@ class PortsScan(PortScanTask):
         rate = self.scan_rate()
 
         if rate == '0':
-            raise StopCommandException("Cancel scan due to low throttling rate {}".format(throttling))
+            raise StopCommandException("Cancel scan due to low throttling rate")
 
         if self.ipv6:
             args.append('-6')


### PR DESCRIPTION
### Description

Cancellable UDP scans. Make it by pushing UDP scan task to executor

ToDo: Rewrite Tasks executing and task management.
Now, there is little bit :spaghetti: in logic.
The proposal is to specify args and kwargs while adding tasks to the task manager.
Alternatively using TaskWrapper by all Tasks

### Status
- [x] Trello card connected
- [x] Unit tests
- [ ] Integration tests
- [x] Dockerization / Puppetization
- [x] Tested on dev server
- [ ] Dependencies are in master
